### PR TITLE
Bugfix: calculation of total active users

### DIFF
--- a/src/ApiKZChatbotRateAnswer.php
+++ b/src/ApiKZChatbotRateAnswer.php
@@ -61,6 +61,14 @@ class ApiKZChatbotRateAnswer extends Handler {
 				400
 			);
 		}
+
+		$answerClassification = $validatedBody['answerClassification'];
+		if ( $answerClassification && !self::isValidAnswerClassification( $answerClassification ) ) {
+			throw new LocalizedHttpException(
+				new MessageValue( 'apierror-badparameter', [ 'answerClassification' ] ),
+				400
+			);
+		}
 	}
 
 	/**
@@ -99,6 +107,20 @@ class ApiKZChatbotRateAnswer extends Handler {
 			]
 		] );
 		return $result->getStatusCode();
+	}
+
+	/**
+	 * @param string $answerClassification
+	 * @return bool
+	 */
+	private static function isValidAnswerClassification( $answerClassification ) {
+		$validAnswerClassifications = [
+			Slugs::getSlug( 'dislike_followup_q_first' ),
+			Slugs::getSlug( 'dislike_followup_q_second' ),
+			Slugs::getSlug( 'dislike_followup_q_third' ),
+		];
+
+		return in_array( $answerClassification, $validAnswerClassifications );
 	}
 
 }

--- a/src/KZChatbot.php
+++ b/src/KZChatbot.php
@@ -63,7 +63,10 @@ class KZChatbot {
 			$activeUsersCount = $dbw->select(
 				[ 'kzchatbot_users' ],
 				[ 'COUNT(*) as count' ],
-				[ 'kzcbu_last_active <= ' . wfTimestamp( TS_MW, time() - ( $activeUsersLimitDays * 24 * 60 * 60 ) ) ],
+				[
+					'kzcbu_is_shown' => 1,
+					'kzcbu_last_active <= ' . wfTimestamp( TS_MW, time() - ( $activeUsersLimitDays * 24 * 60 * 60 ) )
+				],
 				__METHOD__,
 			)->fetchRow();
 			$isShown = empty( $activeUsersCount['count'] ) ? 1 : ( $activeUsersLimit < $activeUsersCount['count'] );


### PR DESCRIPTION
Total active users should only include those selected to see the chatbot.

Without this change, the total includes users who within the 'active_users_limit_days' timeframe were selected to not see the chatbot.