### PR TITLE
Port the stale-user prune to REL1_43

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,36 @@ The `Special:KZChatbotRagTesting` page provides a robust batch testing interface
 - Enable debug data when investigating response quality issues
 - Use manual retry for queries that failed due to temporary issues
 
+## Maintenance Scripts
+
+### Pruning stale user records
+
+#### The issue
+Rows in `kzchatbot_users` are created when a visitor is selected to see the chatbot, but they are never deleted automatically. Once a row's `kzcbu_last_active` falls outside the **Active Users Limit Days** window, the row stops counting toward the active-users cap (`KZChatbot::getCurrentActiveUsersCount`) yet remains in the table indefinitely. Over time the table grows without bound, which slows down the active-users count query and bloats backups.
+
+Note: `kzcbu_cookie_expiry` is **not** the right signal for staleness — it tracks the client-side cookie lifetime, not server-side row liveness. The API recomputes the cookie expiry on every `getStatus` call (`ApiKZChatbotGetStatus::execute`), so the stored DB value is currently unused (see TODO under [Future Development](#future-development)).
+
+#### The solution
+`maintenance/pruneStaleUsers.php` deletes rows whose `kzcbu_last_active` is older than the cutoff, in replication-friendly batches.
+
+Run from the MediaWiki root:
+```bash
+php extensions/KZChatbot/maintenance/pruneStaleUsers.php [options]
+```
+
+| Option            | Description                                                                                                                                                            |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--dry-run`       | Report the cutoff date and how many of the total rows would be removed, then exit without deleting.                                                                    |
+| `--cutoff-days N` | Override the inactivity threshold in days. Defaults to the saved `active_users_limit_days` setting, so the prune cutoff and the active-users count stay in lockstep.   |
+| `--batch-size N`  | Rows to delete per batch (default 1000). `waitForReplication()` is called between batches to bound replica lag.                                                        |
+
+Recommended cron (daily, off-peak):
+```cron
+30 3 * * * www-data php /path/to/mediawiki/extensions/KZChatbot/maintenance/pruneStaleUsers.php
+```
+
+The script refuses to run if the resolved cutoff is ≤ 0, so a missing or zeroed setting can't accidentally wipe the table.
+
 ## Future Development
 - Prevent users from sending unlimited rating requests: right now it's possible to switch indefinitely between 
   thumbs up and thumbs down, and each is sent and recorded by the RAG server. We need to decide on a limit, and save
@@ -248,4 +278,5 @@ The `Special:KZChatbotRagTesting` page provides a robust batch testing interface
 - Consider caching in memory the count of active users to avoid querying the database on every request
 - What is kzchatbot_users.kzcbu_ranking_eligible_answer_id?
 - Implement UUID request limit functionality
+- @TODO: `kzchatbot_users.kzcbu_cookie_expiry` (and its index) appears to be dead weight — it is written by `KZChatbot::newUser()` but never read anywhere in PHP, JS, or templates (the API recomputes the cookie expiry on every `getStatus` call). If further investigation confirms this, drop the column and its index in a schema update.
 

--- a/maintenance/pruneStaleUsers.php
+++ b/maintenance/pruneStaleUsers.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace MediaWiki\Extension\KZChatbot\Maintenance;
+
+use Maintenance;
+use MediaWiki\Extension\KZChatbot\KZChatbot;
+use MediaWiki\MediaWikiServices;
+
+$IP = getenv( 'MW_INSTALL_PATH' );
+if ( $IP === false ) {
+	$IP = __DIR__ . '/../../..';
+}
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * Delete kzchatbot_users rows whose kzcbu_last_active is older than the
+ * "active users limit" window. Such rows no longer count toward the
+ * active-users cap (see KZChatbot::getCurrentActiveUsersCount), so they
+ * are dead weight in the table.
+ */
+class PruneStaleUsers extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription(
+			'Delete kzchatbot_users rows whose last_active is older than the '
+			. 'configured active-users window.'
+		);
+		$this->addOption(
+			'dry-run',
+			'Report the cutoff date and how many rows would be removed, then exit.',
+			false, false
+		);
+		$this->addOption(
+			'cutoff-days',
+			'Override the inactivity threshold in days (defaults to the '
+			. '"active_users_limit_days" setting).',
+			false, true
+		);
+		$this->setBatchSize( 1000 );
+		$this->requireExtension( 'KZChatbot' );
+	}
+
+	public function execute() {
+		$cutoffDays = $this->resolveCutoffDays();
+		if ( $cutoffDays <= 0 ) {
+			$this->fatalError(
+				"Refusing to run: cutoff-days must be > 0 (got $cutoffDays). "
+				. "Check the 'active_users_limit_days' setting or pass --cutoff-days."
+			);
+		}
+
+		$cutoffUnix = time() - ( $cutoffDays * 24 * 60 * 60 );
+		$cutoffTs = wfTimestamp( TS_MW, $cutoffUnix );
+		$cutoffHuman = wfTimestamp( TS_ISO_8601, $cutoffUnix );
+
+		$dbr = wfGetDB( DB_REPLICA );
+		$totalRows = (int)$dbr->selectField(
+			'kzchatbot_users', 'COUNT(*)', [], __METHOD__
+		);
+		$staleRows = (int)$dbr->selectField(
+			'kzchatbot_users',
+			'COUNT(*)',
+			[ 'kzcbu_last_active < ' . $dbr->addQuotes( $cutoffTs ) ],
+			__METHOD__
+		);
+
+		$this->output( "Cutoff: $cutoffHuman (last_active older than $cutoffDays days)\n" );
+		$this->output( "Stale rows: $staleRows of $totalRows total\n" );
+
+		if ( $this->hasOption( 'dry-run' ) ) {
+			$this->output( "Dry run — no rows deleted.\n" );
+			return;
+		}
+
+		if ( $staleRows === 0 ) {
+			$this->output( "Nothing to do.\n" );
+			return;
+		}
+
+		$dbw = wfGetDB( DB_PRIMARY );
+		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
+		$batchSize = $this->getBatchSize();
+		$deleted = 0;
+
+		do {
+			$uuids = $dbw->selectFieldValues(
+				'kzchatbot_users',
+				'kzcbu_uuid',
+				[ 'kzcbu_last_active < ' . $dbw->addQuotes( $cutoffTs ) ],
+				__METHOD__,
+				[ 'LIMIT' => $batchSize ]
+			);
+			if ( !$uuids ) {
+				break;
+			}
+			$dbw->delete(
+				'kzchatbot_users',
+				[ 'kzcbu_uuid' => $uuids ],
+				__METHOD__
+			);
+			$deleted += count( $uuids );
+			$this->output( "  ...deleted $deleted / $staleRows\n" );
+			$lbFactory->waitForReplication();
+		} while ( count( $uuids ) === $batchSize );
+
+		$this->output( "Done. Deleted $deleted stale user row(s).\n" );
+	}
+
+	private function resolveCutoffDays(): int {
+		$override = $this->getOption( 'cutoff-days' );
+		if ( $override !== null ) {
+			return (int)$override;
+		}
+		$settings = KZChatbot::getGeneralSettings();
+		return (int)( $settings['active_users_limit_days'] ?? 30 );
+	}
+}
+
+$maintClass = PruneStaleUsers::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/pruneStaleUsers.php
+++ b/maintenance/pruneStaleUsers.php
@@ -54,27 +54,24 @@ class PruneStaleUsers extends Maintenance {
 		$cutoffTs = wfTimestamp( TS_MW, $cutoffUnix );
 		$cutoffHuman = wfTimestamp( TS_ISO_8601, $cutoffUnix );
 
-		$dbr = wfGetDB( DB_REPLICA );
-		$totalRows = (int)$dbr->selectField(
-			'kzchatbot_users', 'COUNT(*)', [], __METHOD__
-		);
-		$staleRows = (int)$dbr->selectField(
-			'kzchatbot_users',
-			'COUNT(*)',
-			[ 'kzcbu_last_active < ' . $dbr->addQuotes( $cutoffTs ) ],
-			__METHOD__
-		);
-
 		$this->output( "Cutoff: $cutoffHuman (last_active older than $cutoffDays days)\n" );
-		$this->output( "Stale rows: $staleRows of $totalRows total\n" );
 
+		// COUNT(*) on this table is a large index scan. Only pay for it when the
+		// figure is the whole point (dry runs); real runs report progress from
+		// the running delete tally instead.
 		if ( $this->hasOption( 'dry-run' ) ) {
+			$dbr = wfGetDB( DB_REPLICA );
+			$totalRows = (int)$dbr->selectField(
+				'kzchatbot_users', 'COUNT(*)', [], __METHOD__
+			);
+			$staleRows = (int)$dbr->selectField(
+				'kzchatbot_users',
+				'COUNT(*)',
+				[ 'kzcbu_last_active < ' . $dbr->addQuotes( $cutoffTs ) ],
+				__METHOD__
+			);
+			$this->output( "Stale rows: $staleRows of $totalRows total\n" );
 			$this->output( "Dry run — no rows deleted.\n" );
-			return;
-		}
-
-		if ( $staleRows === 0 ) {
-			$this->output( "Nothing to do.\n" );
 			return;
 		}
 
@@ -82,6 +79,7 @@ class PruneStaleUsers extends Maintenance {
 		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 		$batchSize = $this->getBatchSize();
 		$deleted = 0;
+		$batch = 0;
 
 		do {
 			$uuids = $dbw->selectFieldValues(
@@ -100,10 +98,17 @@ class PruneStaleUsers extends Maintenance {
 				__METHOD__
 			);
 			$deleted += count( $uuids );
-			$this->output( "  ...deleted $deleted / $staleRows\n" );
-			$lbFactory->waitForReplication();
+
+			// Blocking on replication after every batch dominates wall-clock on
+			// large purges. Throttle it: every 10 batches keeps replica lag
+			// bounded without the per-batch stall.
+			if ( ++$batch % 10 === 0 ) {
+				$this->output( "  ...deleted $deleted\n" );
+				$lbFactory->waitForReplication();
+			}
 		} while ( count( $uuids ) === $batchSize );
 
+		$lbFactory->waitForReplication();
 		$this->output( "Done. Deleted $deleted stale user row(s).\n" );
 	}
 

--- a/maintenance/pruneStaleUsers.php
+++ b/maintenance/pruneStaleUsers.php
@@ -60,7 +60,7 @@ class PruneStaleUsers extends Maintenance {
 		// figure is the whole point (dry runs); real runs report progress from
 		// the running delete tally instead.
 		if ( $this->hasOption( 'dry-run' ) ) {
-			$dbr = wfGetDB( DB_REPLICA );
+			$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 			$totalRows = (int)$dbr->selectField(
 				'kzchatbot_users', 'COUNT(*)', [], __METHOD__
 			);
@@ -75,7 +75,7 @@ class PruneStaleUsers extends Maintenance {
 			return;
 		}
 
-		$dbw = wfGetDB( DB_PRIMARY );
+		$dbw = MediaWikiServices::getInstance()->getConnectionProvider()->getPrimaryDatabase();
 		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 		$batchSize = $this->getBatchSize();
 		$deleted = 0;


### PR DESCRIPTION
Backports `maintenance/pruneStaleUsers.php` from `main` to `REL1_43`.

## Why

The prune cron has been running on legacy prod since ~2026-06-27, but the
script only ever existed on `main`. `REL1_43` — the branch the new stack
builds from — has no `maintenance/` directory at all, so the job would
silently disappear at cutover. This closes that gap.

## Commits

| Commit | Origin |
|---|---|
| Prevent unbounded growth of kzchatbot_users | cherry-pick of `7f2466e` |
| Keep stale-user prune fast as the table grows | cherry-pick of `99a2e23` |
| Use getConnectionProvider() in the stale-user prune | new, see below |

Both cherry-picks applied without conflict, and the resulting
`pruneStaleUsers.php` + `README.md` were verified byte-identical to
`origin/main` before the third commit.

## The one deliberate divergence from `main`

`main` still uses `wfGetDB()`; `REL1_43` deliberately does not — 61438ea
and e9be617 replaced it with
`MediaWikiServices::getInstance()->getConnectionProvider()`. The
cherry-picked script reintroduced it at two call sites, so the third
commit ports them to the branch idiom.

Left alone on purpose, to keep the port minimal:
- old-style `->selectField()` / `->delete()` — no query builders are used
  anywhere in `src/` on this branch, so these are consistent as-is
- `getDBLoadBalancerFactory()` for `waitForReplication()` — not deprecated
  in 1.43 (core only says "prefer getConnectionProvider() when possible",
  and that interface doesn't expose `waitForReplication()`)
- the three remaining `wfGetDB()` calls in `src/BannedWord.php` —
  pre-existing, out of scope here

## Verification

- `php -l` and `vendor/bin/parallel-lint` — clean
- `vendor/bin/phpcs -sp --standard=.phpcs.xml maintenance/pruneStaleUsers.php` — clean
- No schema/SQL or `extension.json` changes, so no `update.php` needed

## Follow-ups (not in this PR)

- Pointer bump in `kz-mediawiki-main` — will also carry `88e0696`, which
  has sat on `REL1_43` unbumped since 2026-05-30
- Ansible cron role in `kz-infrastructure` to actually schedule it in the
  new stack