### PR TITLE
Restore chatbot answers and stop leaking PHP errors to readers

### DIFF
--- a/src/ApiKZChatbotSubmitQuestion.php
+++ b/src/ApiKZChatbotSubmitQuestion.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\Validator\JsonBodyValidator;
 use MWException;
 use RequestContext;
+use Throwable;
 use Title;
 use Wikimedia\ParamValidator\ParamValidator;
 
@@ -32,11 +33,45 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 	/**
 	 * Pass user question to RAG backend, checking first that user hasn't exceeded daily limit.
 	 * Return answer from RAG backend.
+	 *
+	 * Acts as this endpoint's error boundary. An uncaught Throwable here would be
+	 * turned by MediaWiki's REST layer into a 500 whose body reads
+	 * `Error: exception of type <Class>` (core's wording when
+	 * $wgShowExceptionDetails is false), and the React client renders the response
+	 * message verbatim into the chat window — so a PHP bug reaches the reader as
+	 * an English class name. Everything unexpected is therefore logged on our own
+	 * channel and re-thrown as the operator-authored `general_error` slug.
+	 *
 	 * @return array
 	 * @throws HttpException
 	 * @throws MWException
 	 */
 	public function execute(): array {
+		try {
+			return $this->answerQuestion();
+		} catch ( HttpException $e ) {
+			// Deliberate: the message is an operator-authored slug, meant for the
+			// reader (daily limit, banned word, character limit, general error).
+			throw $e;
+		} catch ( Throwable $e ) {
+			KZChatbot::getLogger()->error(
+				'Unhandled error answering a chatbot question: {exception_class}: {exception_message}',
+				[
+					'exception' => $e,
+					'exception_class' => get_class( $e ),
+					'exception_message' => $e->getMessage(),
+				]
+			);
+			throw new HttpException( Slugs::getSlug( 'general_error' ), 500 );
+		}
+	}
+
+	/**
+	 * @return array
+	 * @throws HttpException
+	 * @throws MWException
+	 */
+	private function answerQuestion(): array {
 		$body = $this->getValidatedBody();
 		$this->uuid = $body['uuid'];
 		$this->validateUser();
@@ -186,24 +221,41 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 	 * @return int|null Page ID if relevant, null otherwise
 	 */
 	private function getRelevantPageId(): ?int {
-		$extensionRegistry = MediaWikiServices::getInstance()->getExtensionRegistry();
-		if ( !$extensionRegistry->isLoaded( 'ChatbotRagContent' ) ) {
+		$services = MediaWikiServices::getInstance();
+		if ( !$services->getExtensionRegistry()->isLoaded( 'ChatbotRagContent' ) ) {
 			return null;
 		}
 
-		$pageId = null;
-		$title = null;
-
 		// Check if referrer is a page ID
-		if ( is_numeric( $this->referrer ) && (int)$this->referrer > 0 ) {
-			$pageId = (int)$this->referrer;
-			$title = Title::newFromID( $pageId );
+		if ( !is_numeric( $this->referrer ) || (int)$this->referrer <= 0 ) {
+			return null;
+		}
+		$pageId = (int)$this->referrer;
+		$title = Title::newFromID( $pageId );
+		if ( !$title ) {
+			return null;
 		}
 
-		if ( $title && ChatbotRagContent::isRelevantTitle( $title ) ) {
-			return $pageId;
+		// Page context is an optional enrichment for the RAG backend, and
+		// ChatbotRagContent is a separate extension whose signature we do not
+		// control. Never let it take the answer down with it: log and ask the
+		// question without page context.
+		try {
+			$isRelevant = ChatbotRagContent::isRelevantTitle(
+				$title,
+				$services->getPageProps(),
+				$services->getMainConfig(),
+				$services->getContentLanguage()
+			);
+		} catch ( Throwable $e ) {
+			KZChatbot::getLogger()->error(
+				'ChatbotRagContent::isRelevantTitle() failed for page {page_id}; '
+					. 'asking without page context',
+				[ 'exception' => $e, 'page_id' => $pageId ]
+			);
+			return null;
 		}
 
-		return null;
+		return $isRelevant ? $pageId : null;
 	}
 }


### PR DESCRIPTION
## What happened

Every chatbot question asked from a real article on **prod** has failed since the
main-site cutover. The reader sees this in the chat window:

> ⓘ Error: exception of type ArgumentCountError

`ChatbotRagContent::isRelevantTitle()` was changed in
`kolzchut/mediawiki-extensions-ChatbotRagContent@229dc90` ("Modernize to MediaWiki
1.43 conventions", 2026-05-18) from

```php
isRelevantTitle( Title $title, bool $ignoreNamespaceCheck = false )
```

to four required parameters, with `PageProps` / `Config` / `Language` injected
instead of pulled from `MediaWikiServices` inside the method. That commit updated
all three callers **inside** ChatbotRagContent (`Hooks.php`,
`RestApiGetContent.php`, its PHPUnit tests) — but the fourth caller lives in this
repo, a different submodule, so it kept passing one argument:

`src/ApiKZChatbotSubmitQuestion.php:203`
```php
if ( $title && ChatbotRagContent::isRelevantTitle( $title ) ) {
```

The path is unconditional in practice: `$wgKZChatbotSendPageId` defaults to `true`
and is overridden nowhere, ChatbotRagContent is loaded on main, and `referrer` is
the current page ID — so `Title::newFromID()` returns a title and the call throws.

### Evidence from prod

`logs/main/kz_he.error.log`:

```
{"message":"[1d121d7bf720b986e5bb7a06] /w/he/rest.php/kzchatbot/v0/question
 ArgumentCountError: Too few arguments to function
 ...ChatbotRagContent::isRelevantTitle(), 1 passed in
 /var/www/html/extensions/KZChatbot/src/ApiKZChatbotSubmitQuestion.php
 on line 203 and at least 4 expected", ...}
```

| | |
|---|---|
| First occurrence | `2026-08-10T22:00:03Z` — the cutover minute; zero in every rotated archive before it |
| Failed questions | 99 on 10 Aug, 1391 on 11 Aug through 10:23 UTC (one log line per distinct request ID) |
| Share of all prod exceptions on 11 Aug | 1391 of 1439 — **96%** |

The bug was built into every image since May. It was unreachable until main's
traffic left the legacy servers, which is why staging carried it silently for
three months.

## Why nobody was told

Three layers each stayed quiet, for different reasons — the PR addresses the two
that live in this repo.

1. **The reader got MediaWiki's internal 500 verbatim.** An uncaught `Throwable`
   in a REST handler becomes `'Error: exception of type ' . get_class( $e )`
   (`ResponseFactory::createFromException`, the `$wgShowExceptionDetails = false`
   branch — prod sets that at `CommonSettings.php:1536`). The React client renders
   the response `message` straight into the chat bubble
   (`Chatbot.tsx:96` → `159-161`) because its contract assumes every non-OK
   message is an operator-authored slug — true for all of *our* errors, false for
   core's. The localized `general_error` fallback only fires for non-HTTP failures.
2. **This extension's own logging never fired.** `KZChatbot::getLogger()` is called
   for a null RAG result and a failed RAG request, but the crash happens earlier,
   in `getRelevantPageId()`, before the backend is contacted. `kz_he.chatbot.log`
   stayed clean and the extension looked healthy.
3. **Nothing alerts on MediaWiki exceptions** (infra-side, out of scope here). Core
   *did* log it — `Router` → `errorReporter` → `exception` channel → `MWLog_CL` in
   Azure Log Analytics. That stream is pull-only; the closest prod signal is the
   `MWLog_CL` canary, which proves the pipeline is alive, not that the error count
   is sane. Tracked separately.

## What this PR changes

**1. Pass the services the callee now expects** — matching how
`RestApiGetContent` and `Hooks` call it:

```php
ChatbotRagContent::isRelevantTitle(
    $title,
    $services->getPageProps(),
    $services->getMainConfig(),
    $services->getContentLanguage()
);
```

**2. Treat page context as optional.** It already is — there's a config flag to
disable it and the code handles `null` — so a fault in a *separate extension whose
signature we do not control* should degrade the enrichment, not kill the answer.
The call is wrapped: on `Throwable`, log and ask the question without `page_id`.
This is the layer that would have kept the chatbot answering through the whole
incident.

**3. Give the endpoint an error boundary.** `execute()` now re-throws
`HttpException` untouched (those messages are deliberate, operator-authored, and
meant for the reader) and converts anything else into a logged
`KZChatbot`-channel error plus `HttpException( Slugs::getSlug( 'general_error' ), 500 )`
— so the reader sees *"אירעה שגיאה במערכת. אנא נסו שנית מאוחר יותר."* instead of a
PHP class name, and the operator gets a stack trace on the extension's own channel.

`getRelevantPageId()` is also flattened to early returns; that's presentation only.

## Verification

Runtime, against the dev stack on the same MW 1.43 build:

```
title=עמוד ראשי exists=true
FOUR_ARG_OK result=true          # the new call executes
ONE_ARG_THROWS ArgumentCountError # the old call still throws — the bug is real
```

`php -l` clean; `phpcs` clean on the changed file, negative-controlled (a
deliberately mis-indented copy raised 3 violations, so green is meaningful).

## Not in this PR

- **Client-side hardening.** `Chatbot.tsx` should refuse to display a server
  `message` on a 5xx and use `t('general_error')` instead — belt and braces for
  faults thrown *outside* `execute()` (the body validator, the Router itself),
  which this PR cannot reach. It needs a rebuild of the committed 411 KB
  `resources/ext.KZChatbot.bot/index.js` bundle, so it's better as its own change.
- **An alert on MediaWiki error volume** (infra repo).
- **A second, adjacent prod bug**, same extension pair, 44 hits on 11 Aug:
  `/w/he/rest.php/cbragcontent/v0/page_id/N` throws
  `TypeError: Cannot assign MediaWiki\Revision\RevisionStoreCacheRecord to property
  ChatbotRagContent\RestApiGetContent::$revisionRecord of type
  ?MediaWiki\Storage\RevisionRecord`. That's the RAG *ingestion* endpoint and it
  belongs in the ChatbotRagContent repo.
