### PR TITLE
Keep the error boundary working when the database is what failed

### DIFF
--- a/src/ApiKZChatbotSubmitQuestion.php
+++ b/src/ApiKZChatbotSubmitQuestion.php
@@ -85,7 +85,15 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 				return $slug;
 			}
 		} catch ( Throwable $e ) {
-			// Fall through to the compiled-in default.
+			// Log rather than fall through in silence. This helper is reached on
+			// paths that previously let the fault escape to the catch-all in
+			// execute(), which logged it; swallowing it here would trade a
+			// reader-facing bug for an invisible operator-facing one, and a
+			// failing slug lookup means the database is in trouble.
+			KZChatbot::getLogger()->warning(
+				'general_error slug lookup failed; using the compiled-in default',
+				[ 'exception' => $e ]
+			);
 		}
 
 		return Slugs::getDefaultSlugs()['general_error'];

--- a/src/ApiKZChatbotSubmitQuestion.php
+++ b/src/ApiKZChatbotSubmitQuestion.php
@@ -62,8 +62,33 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 					'exception_message' => $e->getMessage(),
 				]
 			);
-			throw new HttpException( Slugs::getSlug( 'general_error' ), 500 );
+			throw new HttpException( $this->generalErrorMessage(), 500 );
 		}
+	}
+
+	/**
+	 * The reader-facing text for an error we did not plan for.
+	 *
+	 * Deliberately does not trust the database. `Slugs::getSlug()` reads
+	 * `kzchatbot_text` and the general settings, so on the one fault most likely
+	 * to reach the catch-all above — a database failure — looking the slug up
+	 * would throw a second time, escape execute(), and hand the reader the raw
+	 * `Error: exception of type DBQueryError` this boundary exists to prevent.
+	 * `Slugs::getDefaultSlugs()` is a compiled-in array, so it always answers.
+	 *
+	 * @return string
+	 */
+	private function generalErrorMessage(): string {
+		try {
+			$slug = Slugs::getSlug( 'general_error' );
+			if ( is_string( $slug ) && $slug !== '' ) {
+				return $slug;
+			}
+		} catch ( Throwable $e ) {
+			// Fall through to the compiled-in default.
+		}
+
+		return Slugs::getDefaultSlugs()['general_error'];
 	}
 
 	/**
@@ -97,7 +122,7 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 			$logMsg = 'RAG backend returned null. Question: ' . $this->question
 				. "\nAnswer: " . print_r( $answer, true );
 			KZChatbot::getLogger()->error( $logMsg );
-			throw new HttpException( Slugs::getSlug( 'general_error' ), 500 );
+			throw new HttpException( $this->generalErrorMessage(), 500 );
 		}
 		return $answer;
 	}
@@ -139,7 +164,7 @@ class ApiKZChatbotSubmitQuestion extends Handler {
 			KZChatbot::getLogger()->error(
 				'RAG backend request failed: ' . $status->getWikiText( false, false, 'en' )
 			);
-			throw new HttpException( Slugs::getSlug( 'general_error' ), 500 );
+			throw new HttpException( $this->generalErrorMessage(), 500 );
 		}
 		$response = json_decode( $req->getContent() );
 		$docs = array_map( static function ( $doc ) {


### PR DESCRIPTION
Closes half of kolzchut/kz-mediawiki-main#98 — the server-side half. See that
issue for why the client half is being handled separately.

## The hole

PR #53 gave the submit-question endpoint an error boundary: any unexpected
`Throwable` is logged on the `KZChatbot` channel and re-thrown as
`HttpException( Slugs::getSlug( 'general_error' ), 500 )`, so the reader sees a
Hebrew message instead of `Error: exception of type <Class>`.

But `Slugs::getSlug()` reads the database — `getSlugs()` → `getSlugsRaw()` →
`getSlugsFromDB()` (a `SELECT` on `kzchatbot_text`), plus
`KZChatbot::getGeneralSettings()`, which is a second round trip.

So when the caught fault **is** a database failure — `validateUser()` raising a
`DBError`, a connection drop mid-request — the slug lookup throws again from
inside the `catch` block, escapes `execute()`, and MediaWiki's REST layer serves
the raw exception text. The boundary held for every fault except the one most
likely to reach it.

Not hypothetical on prod: three MySQL `1412 Table definition has changed` errors
were logged during the 2026-08-11 deploy window. Those were transient DDL
contention rather than an outage, but they are the shape that trips this.

## The fix

Route all three `general_error` sites through one helper that does not trust the
database:

```php
private function generalErrorMessage(): string {
    try {
        $slug = Slugs::getSlug( 'general_error' );
        if ( is_string( $slug ) && $slug !== '' ) {
            return $slug;
        }
    } catch ( Throwable $e ) {
        // Fall through to the compiled-in default.
    }
    return Slugs::getDefaultSlugs()['general_error'];
}
```

`Slugs::getDefaultSlugs()` is a literal array in the source with no DB access,
and `general_error` is unconditionally present in it — so the operator's DB
override still wins whenever the DB is reachable, and there is no second Hebrew
string to keep in sync. No hardcoded message was added.

This also closes the latent `?string` → `HttpException( string $message )`
mismatch flagged in review: `getSlug()` is nullable, `generalErrorMessage()` is
not.

Applied at all three sites, not just the catch-all — the RAG-null and
RAG-request-failed paths call the same lookup, and a DB fault there would
otherwise be relabelled as an unhandled bug by the outer boundary rather than
reported cleanly.

## Verification

- `Slugs::getDefaultSlugs()['general_error']` returns
  `אירעה שגיאה במערכת. אנא נסו שנית מאוחר יותר.` with no DB read — confirmed at
  runtime on the dev stack (`maintenance/run.php eval`, KZChatbot loaded via
  `-e CHATBOT_LLM_API_URL`).
- `parallel-lint` clean across all 14 files; `phpcs` clean on the changed file.

## Not in this PR

The React client still renders any server `message` verbatim, which matters for
faults thrown *outside* `execute()` (the 415 from `getBodyValidator()`, a
malformed body rejected by `JsonBodyValidator`, a 502 from the edge). That fix
belongs in `kolzchut/react-app-KZChatbot` and is entangled with 21 unshipped
commits on that repo's `main` — see kolzchut/kz-mediawiki-main#98.

Also deliberately not done: rate-limiting the degradation log added in #53. One
line per failed request is the right volume, `logrotate` is live on prod, and
sampling it would suppress the signal kolzchut/kz-infrastructure#823 exists to
alert on.
