### PR TITLE
Let admins delete slug overrides left behind by renamed slugs

### DIFF
--- a/src/Slugs.php
+++ b/src/Slugs.php
@@ -93,22 +93,29 @@ class Slugs {
 
 	/**
 	 * @param string $slug
-	 * @return bool
-	 * @throws \MWException
+	 * @return \Status Good (with embedded success message) on success; Fatal on unknown slug name
 	 */
-	public static function deleteSlug( string $slug ): bool {
-		if ( !self::isValidSlugName( $slug ) ) {
-			throw new \MWException( 'invalid slug name' );
+	public static function deleteSlug( string $slug ): \Status {
+		// An override row can outlive the default it was named after: slugs get
+		// renamed and retired, but nothing migrates or drops the rows saved under
+		// the old keys. Special:KZChatbotSlugs lists those orphans and offers a
+		// delete link for them, so validating against the current defaults alone
+		// would reject the one operation that clears them up.
+		if ( !self::isValidSlugName( $slug ) && !array_key_exists( $slug, self::getSlugsFromDB() ) ) {
+			return \Status::newFatal( new \RawMessage( 'invalid slug name' ) );
 		}
 
 		// Reset the static cache, so it is refreshed next time
 		self::$slugsRaw = null;
 
 		$dbw = MediaWikiServices::getInstance()->getConnectionProvider()->getPrimaryDatabase();
-		return $dbw->delete(
+		$dbw->delete(
 			'kzchatbot_text',
-			[ 'kzcbt_slug' => $slug ]
+			[ 'kzcbt_slug' => $slug ],
+			__METHOD__
 		);
+
+		return \Status::newGood( [ 'kzchatbot-slugs-status-delete-success', $slug ] );
 	}
 
 	/**

--- a/src/SpecialKZChatbotSlugs.php
+++ b/src/SpecialKZChatbotSlugs.php
@@ -293,17 +293,19 @@ class SpecialKZChatbotSlugs extends SpecialPage {
 	 */
 	public function handleSlugDelete( $slug ): bool {
 		// Delete word/pattern.
-		$result = Slugs::deleteSlug( $slug );
+		$status = Slugs::deleteSlug( $slug );
 
-		if ( $result ) {
+		if ( $status->isOK() ) {
 			// Set session data for the success message
 			$this->getRequest()->getSession()->set( 'kzSlugDeleted', $slug );
+		} else {
+			$this->getRequest()->getSession()->set( 'kzSlugError', $status->getMessage()->plain() );
 		}
 
 		// Return to form.
 		$url = $this->getPageTitle()->getFullUrlForRedirect();
 		$this->getOutput()->redirect( $url );
-		return $result;
+		return $status->isOK();
 	}
 
 }


### PR DESCRIPTION
## The production error

Clicking **Delete** on a row in Special:KZChatbotSlugs returned an internal
error page (`kz_he`, 2026-08-12 09:26 UTC):

```
MWException: invalid slug name
  at extensions/KZChatbot/src/Slugs.php:101
  from extensions/KZChatbot/src/SpecialKZChatbotSlugs.php:296
URL: /w/he/index.php?title=Special:KZChatbotSlugs&delete=welcome_message_first
```

The row is **not** deleted. The throw is the first statement in
`Slugs::deleteSlug()`, before the DB write, so the override survives and
retrying cannot help.

## Cause

`deleteSlug()` validated the slug against `getDefaultSlugs()`. That set changed
when `welcome_message_first` was renamed to `welcome_message` and
`_second`/`_third` were dropped, but nothing migrated or removed the
`kzchatbot_text` rows saved under the old keys.

Special:KZChatbotSlugs builds its table as *defaults ∪ DB rows*, so the orphans
are still listed, and because they come from the DB they are marked
`changed => true` — precisely the condition that renders the Delete link. The
UI offers the one operation the model rejects.

Two defects compound:

1. `deleteSlug()` refused to delete an override row whose key is no longer a
   current default — exactly the rows that need clearing up.
2. `handleSlugDelete()` had no error branch, so any failure became a 500. The
   sibling save path already returns a `Status` and renders a friendly error
   box via the `kzSlugError` session key.

## The change

- `deleteSlug()` accepts a slug that is either a current default **or** actually
  present in `kzchatbot_text`, and returns a `Status` instead of throwing.
- `handleSlugDelete()` mirrors `handleSlugSave()`: success message on OK, error
  box otherwise. No new plumbing — `execute()` already renders `kzSlugError`.
- Drops a use of `MWException`, which is deprecated in MW 1.43, and passes
  `__METHOD__` to `delete()` for query profiling.

## Verification

Reproduced against a copy of the production database, then re-tested after the
change. Before: HTTP 500 on both cases below.

| Case | After |
|---|---|
| Delete orphan `welcome_message_first` (the production URL) | HTTP 200, row removed, success box |
| Delete unknown `no_such_slug_at_all` | HTTP 200, error box, no fatal |
| Delete a current default with an override | HTTP 200, row removed |
| `saveSlug()` reset-to-default path, which delegates to `deleteSlug()` | unchanged |

No new entries in the exception log for the post-fix requests. `phpcs` and
`parallel-lint` clean.

## Note on the affected production data

The orphaned `welcome_message_first` row holds a customised welcome message. It
is shipped to the browser inside `KZChatbotConfig.slugs` but never read — the
React bundle looks up only `welcome_message` (`_0 = new Set(["welcome_message"])`)
— so it has no user-visible effect. It is inert data that admins currently
cannot remove; once this ships, the orphan rows can be deleted from the UI.

I was unable to file a tracking issue (permission denied in my environment), so
the detail lives here.