### PR TITLE
Cover the slug page with integration tests

### DIFF
--- a/src/Slugs.php
+++ b/src/Slugs.php
@@ -6,9 +6,17 @@ use MediaWiki\MediaWikiServices;
 
 class Slugs {
 	/**
+	 * Memoised merge of the defaults and the database overrides, so a request
+	 * that asks for several slugs runs one SELECT rather than one per slug.
+	 * Null means "not loaded", which is also how deleteSlug() invalidates it.
+	 *
+	 * The `= null` default matters: a typed static property declared without one
+	 * is *uninitialized* rather than null, and reading it outside an isset()
+	 * guard would be a fatal instead of a null.
+	 *
 	 * @var array|null of texts
 	 */
-	protected static ?array $slugsRaw;
+	protected static ?array $slugsRaw = null;
 
 	/**
 	 * @param string $slugName

--- a/src/SpecialKZChatbotSlugs.php
+++ b/src/SpecialKZChatbotSlugs.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\KZChatbot;
 
 use Html;
 use HTMLForm;
+use MediaWiki\Message\Message;
 use SpecialPage;
 
 /**
@@ -23,8 +24,8 @@ class SpecialKZChatbotSlugs extends SpecialPage {
 	/**
 	 * @inheritDoc
 	 */
-	public function getDescription() {
-		return $this->msg( 'kzchatbot-slugs-title' )->text();
+	public function getDescription(): Message {
+		return $this->msg( 'kzchatbot-slugs-title' );
 	}
 
 	/**

--- a/tests/phpunit/integration/SlugsTest.php
+++ b/tests/phpunit/integration/SlugsTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace MediaWiki\Extension\KZChatbot\Tests\Integration;
+
+use MediaWiki\Extension\KZChatbot\Slugs;
+use MediaWikiIntegrationTestCase;
+use ReflectionProperty;
+
+/**
+ * @covers \MediaWiki\Extension\KZChatbot\Slugs
+ * @group Database
+ */
+class SlugsTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * A slug that is deliberately not one of the extension's defaults, standing
+	 * in for a key that was renamed or retired while its override row stayed
+	 * behind. Guarded by assertions below so it cannot silently become real.
+	 */
+	private const RETIRED_SLUG = 'retired_slug_for_testing';
+
+	/** A key that is a current default, for the ordinary override case. */
+	private const LIVE_SLUG = 'send_button';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->clearSlugCache();
+	}
+
+	protected function tearDown(): void {
+		$this->clearSlugCache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Slugs memoises the merged slug list in a static property, which survives
+	 * between tests in the same PHP process and would otherwise let one test
+	 * see another's slugs.
+	 */
+	private function clearSlugCache(): void {
+		$cache = new ReflectionProperty( Slugs::class, 'slugsRaw' );
+		$cache->setAccessible( true );
+		$cache->setValue( null, null );
+	}
+
+	private function insertOverride( string $slug, string $text ): void {
+		$this->getDb()->newInsertQueryBuilder()
+			->insertInto( 'kzchatbot_text' )
+			->row( [ 'kzcbt_slug' => $slug, 'kzcbt_text' => $text ] )
+			->caller( __METHOD__ )
+			->execute();
+		$this->clearSlugCache();
+	}
+
+	private function storedSlugs(): array {
+		return array_keys( Slugs::getSlugsFromDB() );
+	}
+
+	public function testRetiredSlugIsNotADefault() {
+		$this->assertFalse(
+			Slugs::isValidSlugName( self::RETIRED_SLUG ),
+			'The fixture slug must not be one of the defaults, or these tests prove nothing'
+		);
+		$this->assertTrue( Slugs::isValidSlugName( self::LIVE_SLUG ) );
+	}
+
+	/**
+	 * The production failure: an override row whose key is no longer a default
+	 * used to throw before reaching the delete, leaving the row in place.
+	 */
+	public function testDeleteRemovesRowWhoseSlugIsNoLongerADefault() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+		$this->assertContains( self::RETIRED_SLUG, $this->storedSlugs() );
+
+		$status = Slugs::deleteSlug( self::RETIRED_SLUG );
+
+		$this->assertStatusGood( $status );
+		$this->assertNotContains( self::RETIRED_SLUG, $this->storedSlugs() );
+	}
+
+	/**
+	 * A slug that is neither a default nor stored is refused — but as a Status,
+	 * not an exception, so the caller can report it instead of fatalling.
+	 */
+	public function testDeleteRefusesSlugThatIsNeitherDefaultNorStored() {
+		$status = Slugs::deleteSlug( 'no_such_slug_anywhere' );
+
+		$this->assertStatusNotOK( $status );
+		$this->assertSame( 'invalid slug name', $status->getMessage()->plain() );
+	}
+
+	public function testDeleteRemovesOverrideOfACurrentDefault() {
+		$this->insertOverride( self::LIVE_SLUG, 'a customised label' );
+
+		$status = Slugs::deleteSlug( self::LIVE_SLUG );
+
+		$this->assertStatusGood( $status );
+		$this->assertNotContains( self::LIVE_SLUG, $this->storedSlugs() );
+	}
+
+	public function testDeleteReportsTheSlugItRemoved() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+
+		$status = Slugs::deleteSlug( self::RETIRED_SLUG );
+
+		$this->assertSame(
+			[ 'kzchatbot-slugs-status-delete-success', self::RETIRED_SLUG ],
+			$status->getValue()
+		);
+	}
+
+	public function testSaveStoresAnOverrideForACurrentDefault() {
+		$status = Slugs::saveSlug( self::LIVE_SLUG, 'a customised label' );
+
+		$this->assertStatusGood( $status );
+		$this->assertContains( self::LIVE_SLUG, $this->storedSlugs() );
+		$this->assertSame( 'a customised label', Slugs::getSlugRaw( self::LIVE_SLUG ) );
+	}
+
+	/**
+	 * Saving text identical to the default drops the row rather than storing a
+	 * redundant copy, and says so with its own message.
+	 */
+	public function testSaveWithDefaultTextRemovesTheOverrideInstead() {
+		$default = Slugs::getDefaultSlugs()[self::LIVE_SLUG];
+		$this->insertOverride( self::LIVE_SLUG, 'a customised label' );
+
+		$status = Slugs::saveSlug( self::LIVE_SLUG, $default );
+
+		$this->assertStatusGood( $status );
+		$this->assertSame(
+			[ 'kzchatbot-slugs-status-reset-success', self::LIVE_SLUG ],
+			$status->getValue()
+		);
+		$this->assertNotContains( self::LIVE_SLUG, $this->storedSlugs() );
+	}
+
+	public function testSaveRefusesASlugThatIsNotADefault() {
+		$status = Slugs::saveSlug( self::RETIRED_SLUG, 'should not be stored' );
+
+		$this->assertStatusNotOK( $status );
+		$this->assertNotContains( self::RETIRED_SLUG, $this->storedSlugs() );
+	}
+
+	/**
+	 * The memo cache must not outlive the row it was built from, or the admin
+	 * would keep being served text they just deleted.
+	 */
+	public function testDeleteInvalidatesTheMemoisedSlugs() {
+		$default = Slugs::getDefaultSlugs()[self::LIVE_SLUG];
+		$this->insertOverride( self::LIVE_SLUG, 'a customised label' );
+
+		// Populate the cache through the memoised path.
+		$this->assertSame( 'a customised label', Slugs::getSlugRaw( self::LIVE_SLUG ) );
+
+		Slugs::deleteSlug( self::LIVE_SLUG );
+
+		$this->assertSame( $default, Slugs::getSlugRaw( self::LIVE_SLUG ) );
+	}
+
+	public function testSaveRefreshesTheMemoisedSlugs() {
+		// Populate the cache before the write, so a stale entry would show up.
+		Slugs::getSlugRaw( self::LIVE_SLUG );
+
+		Slugs::saveSlug( self::LIVE_SLUG, 'a customised label' );
+
+		$this->assertSame( 'a customised label', Slugs::getSlugRaw( self::LIVE_SLUG ) );
+	}
+
+	/**
+	 * Overrides win over defaults, and defaults fill every gap.
+	 */
+	public function testRawSlugsMergeDefaultsWithOverrides() {
+		$this->insertOverride( self::LIVE_SLUG, 'a customised label' );
+
+		$raw = Slugs::getSlugsRaw();
+
+		$this->assertSame( 'a customised label', $raw[self::LIVE_SLUG] );
+		foreach ( array_keys( Slugs::getDefaultSlugs() ) as $name ) {
+			$this->assertArrayHasKey( $name, $raw );
+		}
+	}
+}

--- a/tests/phpunit/integration/SpecialKZChatbotSlugsTest.php
+++ b/tests/phpunit/integration/SpecialKZChatbotSlugsTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace MediaWiki\Extension\KZChatbot\Tests\Integration;
+
+use MediaWiki\Extension\KZChatbot\Slugs;
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotSlugs;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Request\FauxRequest;
+use ReflectionProperty;
+use SpecialPageTestBase;
+
+/**
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotSlugs
+ * @group Database
+ */
+class SpecialKZChatbotSlugsTest extends SpecialPageTestBase {
+
+	/** Stands in for a key that was renamed or retired, leaving its row behind. */
+	private const RETIRED_SLUG = 'retired_slug_for_testing';
+
+	/** A key that is a current default. */
+	private const LIVE_SLUG = 'send_button';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->clearSlugCache();
+	}
+
+	protected function tearDown(): void {
+		$this->clearSlugCache();
+		parent::tearDown();
+	}
+
+	protected function newSpecialPage() {
+		return new SpecialKZChatbotSlugs();
+	}
+
+	private function clearSlugCache(): void {
+		$cache = new ReflectionProperty( Slugs::class, 'slugsRaw' );
+		$cache->setAccessible( true );
+		$cache->setValue( null, null );
+	}
+
+	private function insertOverride( string $slug, string $text ): void {
+		$this->getDb()->newInsertQueryBuilder()
+			->insertInto( 'kzchatbot_text' )
+			->row( [ 'kzcbt_slug' => $slug, 'kzcbt_text' => $text ] )
+			->caller( __METHOD__ )
+			->execute();
+		$this->clearSlugCache();
+	}
+
+	private function storedText( string $slug ): ?string {
+		$this->clearSlugCache();
+		return Slugs::getSlugsFromDB()[$slug] ?? null;
+	}
+
+	/**
+	 * An admin allowed to manage the chatbot's texts. A real user in the real
+	 * group, because SpecialPage::userCanExecute() resolves rights through
+	 * PermissionManager from a User rather than from the context Authority — a
+	 * mock authority's permission list would never be consulted.
+	 */
+	private function admin(): Authority {
+		return $this->getTestUser( [ 'chatbot-admin' ] )->getUser();
+	}
+
+	private function executeAsAdmin( FauxRequest $request ): array {
+		return $this->executeSpecialPage( '', $request, 'qqx', $this->admin() );
+	}
+
+	public function testRetiredSlugIsNotADefault() {
+		$this->assertFalse(
+			Slugs::isValidSlugName( self::RETIRED_SLUG ),
+			'The fixture slug must not be one of the defaults, or these tests prove nothing'
+		);
+	}
+
+	public function testObsoleteRowIsMarkedInTheTable() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+
+		[ $html ] = $this->executeAsAdmin( new FauxRequest() );
+
+		$this->assertStringContainsString( 'obsolete-value', $html );
+		$this->assertStringContainsString( 'kzchatbot-slugs-obsolete', $html );
+	}
+
+	public function testObsoleteRowOffersDeleteButNotEdit() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+
+		[ $html ] = $this->executeAsAdmin( new FauxRequest() );
+
+		$this->assertStringContainsString( 'delete=' . self::RETIRED_SLUG, $html );
+		$this->assertStringNotContainsString( 'edit=' . self::RETIRED_SLUG, $html );
+	}
+
+	public function testCurrentDefaultKeepsItsEditLink() {
+		[ $html ] = $this->executeAsAdmin( new FauxRequest() );
+
+		$this->assertStringContainsString( 'edit=' . self::LIVE_SLUG, $html );
+	}
+
+	/**
+	 * The edit link is omitted for obsolete rows, but the URL stays reachable,
+	 * so the page itself has to refuse.
+	 */
+	public function testEditFormIsRefusedForAnObsoleteSlug() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+		$request = new FauxRequest( [ 'edit' => self::RETIRED_SLUG ], false, [] );
+
+		[ $html, $response ] = $this->executeAsAdmin( $request );
+
+		$this->assertNotSame( '', (string)$response->getHeader( 'Location' ) );
+		$this->assertStringNotContainsString( 'KZChatbotSlugForm', $html );
+		$this->assertStringContainsString(
+			'kzchatbot-slugs-error-obsolete',
+			(string)$request->getSession()->get( 'kzSlugError' )
+		);
+	}
+
+	public function testEditFormStillOpensForACurrentDefault() {
+		$request = new FauxRequest( [ 'edit' => self::LIVE_SLUG ], false, [] );
+
+		[ $html ] = $this->executeAsAdmin( $request );
+
+		$this->assertStringContainsString( 'KZChatbotSlugForm', $html );
+	}
+
+	/**
+	 * A submission aimed at an obsolete slug must not reach the database.
+	 *
+	 * Note this invariant does not depend on the page's own guard:
+	 * Slugs::saveSlug() refuses a name that is not a current default, and the
+	 * kzcSlug field's validation-callback refuses it before that. The guard
+	 * adds the explanation, not the protection — see the test below.
+	 */
+	public function testEditSubmissionNeverReachesTheDatabaseForAnObsoleteSlug() {
+		$this->insertOverride( self::RETIRED_SLUG, 'original text' );
+
+		$this->executeAsAdmin( $this->obsoleteEditSubmission() );
+
+		$this->assertSame( 'original text', $this->storedText( self::RETIRED_SLUG ) );
+	}
+
+	/**
+	 * Without the page's guard a submission aimed at an obsolete slug fails
+	 * silently: field validation rejects it before the submit callback runs, so
+	 * nothing is stored in the session and the admin is returned to an
+	 * unchanged table with no explanation at all.
+	 */
+	public function testEditSubmissionForAnObsoleteSlugExplainsItself() {
+		$this->insertOverride( self::RETIRED_SLUG, 'original text' );
+		$request = $this->obsoleteEditSubmission();
+
+		$this->executeAsAdmin( $request );
+
+		$this->assertStringContainsString(
+			'kzchatbot-slugs-error-obsolete',
+			(string)$request->getSession()->get( 'kzSlugError' )
+		);
+	}
+
+	private function obsoleteEditSubmission(): FauxRequest {
+		return new FauxRequest( [
+			'wpkzcAction' => 'edit',
+			'wpkzcSlug' => self::RETIRED_SLUG,
+			'wpkzcText' => 'text from a hand-made submission',
+			'wpFormIdentifier' => 'KZChatbotSlugForm',
+		], true, [] );
+	}
+
+	/**
+	 * The save stores its message in the session and redirects. If the same
+	 * request goes on to read that message it clears it, and the page the
+	 * browser actually lands on has nothing left to show.
+	 */
+	public function testSaveLeavesItsConfirmationForTheRedirectedPage() {
+		$request = new FauxRequest( [
+			'wpkzcAction' => 'edit',
+			'wpkzcSlug' => self::LIVE_SLUG,
+			'wpkzcText' => 'a customised label',
+			'wpFormIdentifier' => 'KZChatbotSlugForm',
+		], true, [] );
+
+		$this->executeAsAdmin( $request );
+
+		$this->assertSame(
+			[ 'kzchatbot-slugs-status-save-success', self::LIVE_SLUG ],
+			$request->getSession()->get( 'kzSlugStatus' ),
+			'The confirmation must still be in the session for the redirected request'
+		);
+		$this->assertSame( 'a customised label', $this->storedText( self::LIVE_SLUG ) );
+	}
+
+	/**
+	 * Deleting used to be a fatal for exactly the rows that needed deleting.
+	 */
+	public function testDeletingAnObsoleteRowSucceedsAndReportsItself() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+		$request = new FauxRequest( [ 'delete' => self::RETIRED_SLUG ], false, [] );
+
+		$this->executeAsAdmin( $request );
+
+		$this->assertNull( $this->storedText( self::RETIRED_SLUG ) );
+		$this->assertSame(
+			self::RETIRED_SLUG,
+			$request->getSession()->get( 'kzSlugDeleted' )
+		);
+	}
+}


### PR DESCRIPTION
**Stacked on PR #56** — based on `feature/mark-obsolete-slugs`, because it tests
behaviour that only exists on that branch. Merge #56 first, then this retargets
to `REL1_43` cleanly.

The extension had no PHP tests at all: `tests/` held a mock RAG server and an
`.eslintrc`, and `composer test` is lint only. So every fix to this page so far
rested on manual checking. This adds the first `tests/phpunit/`, following the
pattern the sibling kolzchut extensions already use (`ChatbotRagContent` has
`tests/phpunit/integration/` on `MediaWikiIntegrationTestCase`).

## Coverage

`SlugsTest` — 12 tests on the model:

- deleting a row whose slug is no longer a default (the original 500)
- refusing a slug that is neither a default nor stored — as a Status, not a throw
- deleting an override of a current default
- saving an override; saving text identical to the default removes the row instead
- refusing to save a slug that is not a default
- the memo cache being invalidated by a delete and refreshed by a save
- defaults and overrides merging, overrides winning

`SpecialKZChatbotSlugsTest` — 11 tests on the page:

- obsolete rows carrying the `obsolete-value` class and the badge
- obsolete rows offering delete but not edit; current defaults keeping their edit link
- `?edit=<obsolete>` refused, with the explanation in the session
- the edit form still opening for a current default
- a submission aimed at an obsolete slug never reaching the database
- that same submission explaining itself rather than failing silently
- **the save confirmation still being in the session after the request that created it**
- deleting an obsolete row succeeding and reporting itself

## Every test was checked against the bug it describes

A passing test proves nothing on its own, so each behaviour was verified by
reintroducing the original bug and confirming the right test — and only that
test — fails:

| Bug reintroduced | Tests that failed |
|---|---|
| `deleteSlug()` throwing on a non-default slug | the 3 delete tests in `SlugsTest`, nothing else |
| removing the post-save `return` | `testSaveLeavesItsConfirmationForTheRedirectedPage` alone |
| removing the obsolete-edit guard | `testEditFormIsRefusedForAnObsoleteSlug` and `testEditSubmissionForAnObsoleteSlugExplainsItself` |

## Correction this surfaced, and it matters for PR #56

That third mutation showed that removing the guard does **not** let a submission
reach the database. `Slugs::saveSlug()` refuses a name that is not a current
default, and the `kzcSlug` field's `validation-callback` refuses it earlier
still. So the guard added in #56 supplies the *explanation*, not the
*protection* — without it the submission fails silently, leaving the admin at an
unchanged table with no feedback.

PR #56's description overstated this, and I have corrected it there. The two
tests are named and documented to keep the distinction visible.

## Two production changes folded in

- `Slugs::$slugsRaw` gains an explicit `= null` default. A typed static declared
  without one is *uninitialized*, not null, so a read outside the `isset()`
  guard would be a fatal rather than a null. No behaviour change.
- `SpecialKZChatbotSlugs::getDescription()` returns a `Message` instead of a
  `string`, matching `SpecialKZChatbotSettings` in this same extension.
  Returning a string has been deprecated since MediaWiki 1.41, and the
  deprecation aborted all eight special page tests, so this was load-bearing
  rather than tidying. `SpecialKZChatbotBannedWords`, `SpecialKZChatbotTesting`
  and `SpecialKZChatbotRagSettings` have the same deprecation and are left
  alone here.

## Running them

There is no CI in this repo and MediaWiki core here is installed without dev
dependencies, so PHPUnit is not available out of the box. With it installed:

```
php tests/phpunit/phpunit.php extensions/KZChatbot/tests/phpunit/integration/
```

Result: `OK (23 tests, 68 assertions)`. `composer phpcs` and `grunt test`
(eslint, stylelint, banana) are clean.

Worth deciding separately whether to add a workflow so this actually gates PRs —
until then the suite only runs when someone runs it.