### PR TITLE
Return a Message from the remaining special page descriptions

### DIFF
--- a/src/SpecialKZChatbotBannedWords.php
+++ b/src/SpecialKZChatbotBannedWords.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\KZChatbot;
 use Exception;
 use Html;
 use HTMLForm;
+use MediaWiki\Message\Message;
 use SpecialPage;
 
 /**
@@ -24,8 +25,8 @@ class SpecialKZChatbotBannedWords extends SpecialPage {
 	/**
 	 * @inheritDoc
 	 */
-	public function getDescription() {
-		return $this->msg( 'kzchatbot-desc' )->text();
+	public function getDescription(): Message {
+		return $this->msg( 'kzchatbot-desc' );
 	}
 
 	/**

--- a/src/SpecialKZChatbotRagSettings.php
+++ b/src/SpecialKZChatbotRagSettings.php
@@ -10,6 +10,7 @@ use Html;
 use HTMLForm;
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Message\Message;
 use PermissionsError;
 use Status;
 
@@ -113,8 +114,8 @@ class SpecialKZChatbotRagSettings extends FormSpecialPage {
 	/**
 	 * @inheritDoc
 	 */
-	public function getDescription(): string {
-		return $this->msg( 'kzchatbot-rag-settings' )->text();
+	public function getDescription(): Message {
+		return $this->msg( 'kzchatbot-rag-settings' );
 	}
 
 	/**

--- a/src/SpecialKZChatbotTesting.php
+++ b/src/SpecialKZChatbotTesting.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\KZChatbot;
 
+use MediaWiki\Message\Message;
 use SpecialPage;
 use TemplateParser;
 
@@ -103,7 +104,7 @@ class SpecialKZChatbotTesting extends SpecialPage {
 	}
 
 	/** @inheritDoc */
-	public function getDescription(): string {
-		return $this->msg( 'kzchatbot-testing-title' )->text();
+	public function getDescription(): Message {
+		return $this->msg( 'kzchatbot-testing-title' );
 	}
 }

--- a/tests/phpunit/integration/SpecialPageDescriptionsTest.php
+++ b/tests/phpunit/integration/SpecialPageDescriptionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MediaWiki\Extension\KZChatbot\Tests\Integration;
+
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotBannedWords;
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotRagSettings;
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotSettings;
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotSlugs;
+use MediaWiki\Extension\KZChatbot\SpecialKZChatbotTesting;
+use MediaWiki\Message\Message;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * Returning a string from SpecialPage::getDescription() has been deprecated
+ * since MediaWiki 1.41, and the deprecation is loud enough to abort any test
+ * that executes the page. Covering every one of the extension's special pages
+ * keeps a new page from reintroducing it.
+ *
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotBannedWords
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotRagSettings
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotSettings
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotSlugs
+ * @covers \MediaWiki\Extension\KZChatbot\SpecialKZChatbotTesting
+ */
+class SpecialPageDescriptionsTest extends MediaWikiIntegrationTestCase {
+
+	public static function provideSpecialPages(): array {
+		return [
+			'banned words' => [ SpecialKZChatbotBannedWords::class ],
+			'rag settings' => [ SpecialKZChatbotRagSettings::class ],
+			'settings' => [ SpecialKZChatbotSettings::class ],
+			'slugs' => [ SpecialKZChatbotSlugs::class ],
+			'testing' => [ SpecialKZChatbotTesting::class ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideSpecialPages
+	 */
+	public function testGetDescriptionReturnsAMessage( string $class ) {
+		$page = new $class();
+
+		$description = $page->getDescription();
+
+		$this->assertInstanceOf( Message::class, $description );
+		$this->assertNotSame( '', $description->text() );
+	}
+}


### PR DESCRIPTION
Follow-up to PR #59, which converted `SpecialKZChatbotSlugs::getDescription()`
because the deprecation was aborting its tests. The same deprecation was left in
place on the other three pages; this clears them.

## Why it matters

Returning a `string` from `SpecialPage::getDescription()` has been deprecated
since MediaWiki 1.41. Two consequences:

1. **It blocks testing.** MediaWiki turns its own deprecation warnings into
   errors under PHPUnit, so any test that executes one of these pages aborts
   before asserting anything. That is exactly what happened on the slug page —
   all eight tests failed on the deprecation until it was fixed.
2. It will stop working outright in a future release.

## What changed

| Page | Before | After |
|---|---|---|
| `SpecialKZChatbotBannedWords` | untyped, returned `->text()` | `: Message` |
| `SpecialKZChatbotTesting` | `: string` | `: Message` |
| `SpecialKZChatbotRagSettings` | `: string` | `: Message` |

`SpecialKZChatbotSettings` and `SpecialKZChatbotSlugs` were already correct, so
all five now agree.

Narrowing the return type is safe: nothing calls `getDescription()` on these
classes. The three hits elsewhere in the extension are on `BannedWord`, an
unrelated model with a method of the same name.

## Test

One data-provider test over all five registered special pages, asserting the
description is a `Message` and renders non-empty. It covers the pages that were
already correct too, so a newly added page cannot quietly reintroduce the
deprecation.

Verified by reverting `SpecialKZChatbotTesting` to the string form: that data
set alone failed. Full suite `OK (30 tests, 80 assertions)`; `composer phpcs`
clean.