### PR TITLE
Require a token to delete a slug or a banned word

### DIFF
--- a/src/SpecialKZChatbotBannedWords.php
+++ b/src/SpecialKZChatbotBannedWords.php
@@ -2,9 +2,11 @@
 
 namespace MediaWiki\Extension\KZChatbot;
 
+use ErrorPageError;
 use Exception;
 use Html;
 use HTMLForm;
+use MediaWiki\Session\CsrfTokenSet;
 use SpecialPage;
 
 /**
@@ -29,6 +31,19 @@ class SpecialKZChatbotBannedWords extends SpecialPage {
 	}
 
 	/**
+	 * CSRF tokens for the request being handled.
+	 *
+	 * Deliberately not $this->getContext()->getCsrfTokenSet(): DerivativeContext
+	 * does not override that method, so it delegates to the context it wraps and
+	 * reads whatever request is global rather than the one this page was given.
+	 *
+	 * @return CsrfTokenSet
+	 */
+	private function getCsrfTokenSet(): CsrfTokenSet {
+		return new CsrfTokenSet( $this->getRequest() );
+	}
+
+	/**
 	 * Special page: Banned words/patterns in the Kol-Zchut chatbot.
 	 * @param string|null $subPage Parameters passed to the page
 	 */
@@ -44,6 +59,13 @@ class SpecialKZChatbotBannedWords extends SpecialPage {
 		if ( isset( $params['delete'] ) && is_numeric( $params['delete'] )
 			&& $params['delete'] == intval( $params['delete'] )
 		) {
+			// Deleting is reached by following a link, so it arrives as a GET that
+			// changes state. Any page an admin merely visits could otherwise fire
+			// one off by embedding this URL. The token ties the request to the
+			// session that was shown the link; core's rollback links do the same.
+			if ( !$this->getCsrfTokenSet()->matchTokenField( 'token' ) ) {
+				throw new ErrorPageError( 'sessionfailure-title', 'sessionfailure' );
+			}
 			$this->handleBannedWordDelete( $params['delete'] );
 			return;
 		}
@@ -124,9 +146,13 @@ class SpecialKZChatbotBannedWords extends SpecialPage {
 			);
 			$deleteLabel = $this->msg( 'kzchatbot-banned-words-op-delete' )->text();
 			$editLabel = $this->msg( 'kzchatbot-banned-words-op-edit' )->text();
+			// One token for every row: it authenticates the session, not the word.
+			$csrfToken = $this->getCsrfTokenSet()->getToken()->toString();
 			for ( $i = 0; $i < count( $bannedWords ); $i++ ) {
 				$word = $bannedWords[$i];
-				$deleteUrl = $output->getTitle()->getLocalURL( [ 'delete' => $word->getId() ] );
+				$deleteUrl = $output->getTitle()->getLocalURL(
+					[ 'delete' => $word->getId(), 'token' => $csrfToken ]
+				);
 				$editUrl = $output->getTitle()->getLocalURL( [ 'edit' => $word->getId() ] );
 				$output->addHTML(
 					Html::openElement( 'tr' )

--- a/src/SpecialKZChatbotSlugs.php
+++ b/src/SpecialKZChatbotSlugs.php
@@ -2,9 +2,11 @@
 
 namespace MediaWiki\Extension\KZChatbot;
 
+use ErrorPageError;
 use Html;
 use HTMLForm;
 use MediaWiki\Message\Message;
+use MediaWiki\Session\CsrfTokenSet;
 use SpecialPage;
 
 /**
@@ -26,6 +28,19 @@ class SpecialKZChatbotSlugs extends SpecialPage {
 	 */
 	public function getDescription(): Message {
 		return $this->msg( 'kzchatbot-slugs-title' );
+	}
+
+	/**
+	 * CSRF tokens for the request being handled.
+	 *
+	 * Deliberately not $this->getContext()->getCsrfTokenSet(): DerivativeContext
+	 * does not override that method, so it delegates to the context it wraps and
+	 * reads whatever request is global rather than the one this page was given.
+	 *
+	 * @return CsrfTokenSet
+	 */
+	private function getCsrfTokenSet(): CsrfTokenSet {
+		return new CsrfTokenSet( $this->getRequest() );
 	}
 
 	/**
@@ -57,6 +72,13 @@ class SpecialKZChatbotSlugs extends SpecialPage {
 		// Delete operation?
 		$queryParams = $this->getRequest()->getQueryValues();
 		if ( !empty( $queryParams['delete'] ) ) {
+			// Deleting is reached by following a link, so it arrives as a GET that
+			// changes state. Any page an admin merely visits could otherwise fire
+			// one off by embedding this URL. The token ties the request to the
+			// session that was shown the link; core's rollback links do the same.
+			if ( !$this->getCsrfTokenSet()->matchTokenField( 'token' ) ) {
+				throw new ErrorPageError( 'sessionfailure-title', 'sessionfailure' );
+			}
 			$this->handleSlugDelete( $queryParams['delete'] );
 			return;
 		}
@@ -217,13 +239,17 @@ class SpecialKZChatbotSlugs extends SpecialPage {
 			$formattingLabel = $this->msg( 'kzchatbot-slugs-formatting-supported' )->text();
 			$obsoleteLabel = $this->msg( 'kzchatbot-slugs-obsolete' )->text();
 			$obsoleteTooltip = $this->msg( 'kzchatbot-slugs-obsolete-tooltip' )->text();
+			// One token for every row: it authenticates the session, not the slug.
+			$csrfToken = $this->getCsrfTokenSet()->getToken()->toString();
 			foreach ( $slugs as $slug => $attribs ) {
 				// A row the chatbot no longer has any use for: it exists only because
 				// an override was saved under a slug that has since been renamed or
 				// retired. Deleting it is the only thing left to do with it.
 				$isObsolete = !Slugs::isValidSlugName( $slug );
 				$editUrl = $output->getTitle()->getLocalURL( [ 'edit' => $slug ] );
-				$deleteUrl = $output->getTitle()->getLocalURL( [ 'delete' => $slug ] );
+				$deleteUrl = $output->getTitle()->getLocalURL(
+					[ 'delete' => $slug, 'token' => $csrfToken ]
+				);
 				if ( $isObsolete ) {
 					$cssClass = 'obsolete-value';
 				} else {

--- a/tests/phpunit/integration/SpecialKZChatbotSlugsTest.php
+++ b/tests/phpunit/integration/SpecialKZChatbotSlugsTest.php
@@ -2,10 +2,12 @@
 
 namespace MediaWiki\Extension\KZChatbot\Tests\Integration;
 
+use ErrorPageError;
 use MediaWiki\Extension\KZChatbot\Slugs;
 use MediaWiki\Extension\KZChatbot\SpecialKZChatbotSlugs;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Request\FauxRequest;
+use MediaWiki\Session\CsrfTokenSet;
 use ReflectionProperty;
 use SpecialPageTestBase;
 
@@ -215,7 +217,7 @@ class SpecialKZChatbotSlugsTest extends SpecialPageTestBase {
 	 */
 	public function testDeletingAnObsoleteRowSucceedsAndReportsItself() {
 		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
-		$request = new FauxRequest( [ 'delete' => self::RETIRED_SLUG ], false, [] );
+		$request = $this->deleteRequest( self::RETIRED_SLUG );
 
 		$this->executeAsAdmin( $request );
 
@@ -224,5 +226,76 @@ class SpecialKZChatbotSlugsTest extends SpecialPageTestBase {
 			self::RETIRED_SLUG,
 			$request->getSession()->get( 'kzSlugDeleted' )
 		);
+	}
+
+	/**
+	 * Deleting is a state change reached by following a link, so it arrives as a
+	 * GET. Without a token, any page an admin visits could delete their slugs by
+	 * embedding the URL.
+	 */
+	public function testDeletingWithoutATokenIsRefused() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+		$request = new FauxRequest( [ 'delete' => self::RETIRED_SLUG ], false, [] );
+
+		$this->expectException( ErrorPageError::class );
+		try {
+			$this->executeAsAdmin( $request );
+		} finally {
+			$this->assertSame(
+				'text left behind by a rename',
+				$this->storedText( self::RETIRED_SLUG ),
+				'An untokened delete must not reach the database'
+			);
+		}
+	}
+
+	public function testDeletingWithSomeoneElsesTokenIsRefused() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+		$request = new FauxRequest(
+			[ 'delete' => self::RETIRED_SLUG, 'token' => 'not-the-right-token+\\' ],
+			false,
+			[]
+		);
+
+		$this->expectException( ErrorPageError::class );
+		try {
+			$this->executeAsAdmin( $request );
+		} finally {
+			$this->assertSame(
+				'text left behind by a rename',
+				$this->storedText( self::RETIRED_SLUG )
+			);
+		}
+	}
+
+	public function testDeleteLinksCarryAToken() {
+		$this->insertOverride( self::RETIRED_SLUG, 'text left behind by a rename' );
+
+		[ $html ] = $this->executeAsAdmin( new FauxRequest() );
+
+		$this->assertMatchesRegularExpression(
+			'/delete=' . preg_quote( self::RETIRED_SLUG, '/' ) . '&(amp;)?token=/',
+			$html
+		);
+	}
+
+	/**
+	 * A delete request carrying the token the page would have put in the link.
+	 * The token comes from the session, so it has to be minted before the
+	 * request that will present it.
+	 */
+	private function deleteRequest( string $slug ): FauxRequest {
+		$request = new FauxRequest( [ 'delete' => $slug ], false, [] );
+
+		// The token has to be minted the way the page will verify it.
+		// CsrfTokenSet short-circuits to the constant logged-out token unless the
+		// *session's* user is registered — setting the performer on the context is
+		// not enough — so the session gets a real user before the token is taken.
+		$request->getSession()->setUser( $this->admin() );
+		$request->setVal(
+			'token',
+			( new CsrfTokenSet( $request ) )->getToken()->toString()
+		);
+		return $request;
 	}
 }


### PR DESCRIPTION
Closes the CSRF hole noted in PR #56 and PR #59.

## The hole

Both admin pages delete by following a plain link:

```php
$deleteUrl = $output->getTitle()->getLocalURL( [ 'delete' => $slug ] );
```

So the deletion arrives as a **GET carrying nothing but the row to remove**. Any
page an administrator merely visits could delete their chatbot texts by
embedding that URL — an `<img src>` is enough, no interaction required. The
browser attaches the session cookie, the page sees a logged-in admin, and the
row is gone.

I found the same pattern on `SpecialKZChatbotBannedWords` (line 129) while
fixing the slug page, so both are covered here rather than leaving a known
duplicate of the same hole in place.

## The fix

Delete links now carry a CSRF token, and both pages refuse a request without a
matching one, throwing `ErrorPageError` with core's `sessionfailure` messages —
the standard response for a token mismatch, so no new i18n.

This is the same shape as core's rollback links: a GET that mutates, protected
by a token. It is the smaller fix. The fuller one would make deletion a POST,
since GET should not change state at all and tokens in URLs can leak through
`Referer` headers and browser history. That is a larger UI change — a form or
confirmation step per row — and worth doing separately if you want it.

## A subtlety worth knowing

The token is taken from the request being handled:

```php
private function getCsrfTokenSet(): CsrfTokenSet {
    return new CsrfTokenSet( $this->getRequest() );
}
```

**not** `$this->getContext()->getCsrfTokenSet()`. `DerivativeContext` does not
override `getCsrfTokenSet()`, so it inherits `ContextSource`'s version, which
delegates to the context it *wraps* — reading whatever request is global rather
than the one the page was given. Harmless when a page runs on the main context,
but it binds the check to the wrong request the moment it does not, and it makes
the behaviour impossible to test.

## Tests

Three new tests on the slug page:

- deleting without a token is refused, and the row survives
- deleting with someone else's token is refused, and the row survives
- rendered delete links carry a token

Verified by removing the check: both refusal tests failed, nothing else did.

The existing `testDeletingAnObsoleteRowSucceedsAndReportsItself` now mints a
real token. That required registering a user **on the session** — not just
setting the performer on the context — because `CsrfTokenSet::getToken()`
short-circuits to the constant logged-out token whenever the session's user is
anonymous. Worth knowing before writing any other token test here.

`OK (27 tests, 74 assertions)`; `composer phpcs` and `grunt test` clean. Also
checked in the browser: the rendered link is
`...&delete=welcome_message_first&token=6ac4bbc0...%2B%5C`.

## Not covered

No tests for the banned-words page — it has no test file yet, and adding one
means fixtures for `kzchatbot_bannedwords` and the `BannedWord` model. Its fix
is line-for-line identical to the slug page's, which is covered. Worth its own
PR.